### PR TITLE
fix ott version parsing

### DIFF
--- a/otc/taxonomy/taxonomy.cpp
+++ b/otc/taxonomy/taxonomy.cpp
@@ -169,7 +169,7 @@ void Taxonomy::write(const std::string& newdirname) {
 }
 
 
-const std::regex ott_version_pattern("^([.0-9]+)draft.*");
+const std::regex ott_version_pattern("^([0-9.]+)draft.*");
 
 Taxonomy::Taxonomy(const string& dir,
                    bitset<32> cf,


### PR DESCRIPTION
(Same as fix on OT fork: https://github.com/OpenTreeOfLife/otcetera/pull/44)

Regards https://github.com/OpenTreeOfLife/otcetera/issues/43
Change involves only `[.0-9]` to `[0-9.]` (as order apparently matter with the regex). Thanks to @jimallman for help.